### PR TITLE
FIX list.column display

### DIFF
--- a/web_widget_one2many_tags/static/src/js/web_widget_one2many_tags.js
+++ b/web_widget_one2many_tags/static/src/js/web_widget_one2many_tags.js
@@ -46,17 +46,12 @@ openerp.web_widget_one2many_tags = function(instance)
         'instance.web_widget_one2many_tags.FieldOne2ManyTags'
     );
 
-    instance.web.list.One2Many_Tags = instance.web.list.Column.extend({
-        _format: function (row_data, options) {
-            // This will just show "(%d records)"
-            // TODO: Show comma separated name_get
-            // I didn't find out how to fetch it and return it here
-            // Another option is to extend instance.web.ListView.List.render_cell
-            // (this is how odoo does it, really nasty..)
-            // See https://github.com/odoo/odoo/blob/8.0/addons/web/static/src/js/view_list.js#L1103
-            return _.escape(instance.web.format_value(
-                row_data[this.id].value, { type: 'many2many' }, options.value_if_empty));
-        }
+    instance.web.list.One2Many_Tags = instance.web.list.Many2Many.extend({
+        init: function () {
+            this._super.apply(this, arguments);
+            // Treat it as many2many to trick odoo into populating '__display'.
+            this.type = 'many2many';
+        },
     });
 
     instance.web.list.columns.add(

--- a/web_widget_one2many_tags/static/src/js/web_widget_one2many_tags.js
+++ b/web_widget_one2many_tags/static/src/js/web_widget_one2many_tags.js
@@ -40,8 +40,27 @@ openerp.web_widget_one2many_tags = function(instance)
             return result;
         },
     });
+
     instance.web.form.widgets.add(
         'one2many_tags',
         'instance.web_widget_one2many_tags.FieldOne2ManyTags'
+    );
+
+    instance.web.list.One2Many_Tags = instance.web.list.Column.extend({
+        _format: function (row_data, options) {
+            // This will just show "(%d records)"
+            // TODO: Show comma separated name_get
+            // I didn't find out how to fetch it and return it here
+            // Another option is to extend instance.web.ListView.List.render_cell
+            // (this is how odoo does it, really nasty..)
+            // See https://github.com/odoo/odoo/blob/8.0/addons/web/static/src/js/view_list.js#L1103
+            return _.escape(instance.web.format_value(
+                row_data[this.id].value, { type: 'many2many' }, options.value_if_empty));
+        }
+    });
+
+    instance.web.list.columns.add(
+        'field.one2many_tags',
+        'instance.web.list.One2Many_Tags'
     );
 }


### PR DESCRIPTION
This should 'FIX' how this widget displays on list view when not editing it 

It falls back to `(%d records)` (as displayed by any `One2Many` widget).

![sin titulo](https://cloud.githubusercontent.com/assets/1914185/13622784/e58dcc14-e57f-11e5-8824-427c5354975c.png)

**TODO:** Show comma separated values returned by name_get
I wasn't able to fetch it and return them inside `_format`, though.
An alternative option is to extend instance.web.ListView.List.render_cell
AFAIK, this is how odoo does it, and it's really nasty..
See https://github.com/odoo/odoo/blob/8.0/addons/web/static/src/js/view_list.js#L1103

https://github.com/OCA/web/pull/319#issuecomment-191764455 
https://github.com/OCA/web/pull/319
