### PR TITLE
[FIX] Correct treatment of ISO week years

### DIFF
--- a/web_widget_date_interval/static/src/js/web_widget_date_interval.js
+++ b/web_widget_date_interval/static/src/js/web_widget_date_interval.js
@@ -1,9 +1,11 @@
-//-*- coding: utf-8 -*-
-//© 2017 Therp BV <http://therp.nl>
-//License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+// -*- coding: utf-8 -*-
+// © 2017 Therp BV <http://therp.nl>
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-openerp.web_widget_date_interval = function(instance)
-{
+/* eslint require-jsdoc:0 */
+
+openerp.web_widget_date_interval = function (instance) {
+    "use strict";
     instance.web.form.widgets.add(
         'date_interval',
         'instance.web_widget_date_interval.FieldDateInterval');
@@ -12,117 +14,100 @@ openerp.web_widget_date_interval = function(instance)
         instance.web.form.ReinitializeFieldMixin,
         {
             events: {
-                'click .weeknumber_iso button':
-                'weeknumber_iso_onchange_year',
-                'change .weeknumber_iso select':
-                'weeknumber_iso_onchange_week',
+                'click .weeknumber_iso button': 'weeknumber_iso_onchange_year',
+                'change .weeknumber_iso select': 'weeknumber_iso_onchange_week',
             },
             template: 'FieldDateInterval',
             className: 'oe_form_date_interval',
-            init: function(field_manager, node)
-            {
+            init: function () {
                 this._super.apply(this, arguments);
-                if(!this.options.type)
-                {
-                    throw 'Pass a type in the options dictionary!';
+                if (!this.options.type) {
+                    throw new Error('Pass a type in the options dictionary!');
                 }
-                if(!this.options.end_field)
-                {
-                    throw 'Pass an end field in the options dictionary';
+                if (!this.options.end_field) {
+                    throw new Error(
+                        'Pass an end field in the options dictionary');
                 }
                 this.on('change:value', this, this.reinitialize);
             },
-            _get_date: function()
-            {
+            _get_date: function () {
                 return instance.web.str_to_date(
                     instance.web.parse_value(
                         this.get_value(), this, Date.now()
                     ).substring(0, 10)
                 );
             },
-            weeknumber_iso_weeknumber: function(date)
-            {
-                // getISOWeek looks at the UTC time, but users expect walltime
+            weeknumber_iso_weeknumber: function (date) {
+                // GetISOWeek looks at the UTC time, but users expect walltime
                 var local = date.clone().clearTime().add(12).hours();
-                return parseInt(local.getISOWeek());
+                return parseInt(local.getISOWeek(), 10);
             },
-            weeknumber_iso_get_years: function()
-            {
-                if(this.options.hide_years)
-                {
+            weeknumber_iso_get_years: function () {
+                if (this.options.hide_years) {
                     return [];
                 }
                 var result = [],
                     years_before = this.options.years_before || 5,
                     years_after = this.options.years_after || 5,
                     current_date = this._get_date();
-                for(
+                for (
                     var year=current_date.getFullYear() - years_before;
                     year <= current_date.getFullYear() + years_after;
                     year++
-                )
-                {
+                ) {
                     result.push(year);
                 }
                 return result;
             },
-            weeknumber_iso_get_weeks: function()
-            {
+            weeknumber_iso_get_weeks: function () {
                 var result = [],
                     last_day = this._get_date(),
                     max_week = 52;
-                if(!last_day.is().december())
-                {
+                if (!last_day.is().december()) {
                     last_day.december();
                 }
                 last_day.moveToLastDayOfMonth();
-                if(this.weeknumber_iso_weeknumber(last_day) > 1)
-                {
+                if (this.weeknumber_iso_weeknumber(last_day) > 1) {
                     max_week = this.weeknumber_iso_weeknumber(last_day);
                 }
-                for(var week=1; week <= max_week; week++)
-                {
+                for (var week=1; week <= max_week; week++) {
                     result.push(week);
                 }
                 return result;
             },
-            weeknumber_iso_onchange_year: function(e)
-            {
-                var year = parseInt(jQuery(e.currentTarget).data('year')),
+            weeknumber_iso_onchange_year: function (e) {
+                var year = parseInt(jQuery(e.currentTarget).data('year'), 10),
                     value = this._get_date();
                 value.setFullYear(year);
                 return this.weeknumber_iso_update_interval(value);
             },
-            weeknumber_iso_onchange_week: function(e)
-            {
-                var week = parseInt(jQuery(e.currentTarget).val());
+            weeknumber_iso_onchange_week: function (e) {
+                var week = parseInt(jQuery(e.currentTarget).val(), 10);
                 return this.weeknumber_iso_update_interval(
                     this._get_date().setWeek(week)
                 );
             },
-            weeknumber_iso_update_interval: function(start)
-            {
+            weeknumber_iso_update_interval: function (start) {
                 return this.update_interval(
                     start.is().monday() ? start : start.last().monday(),
-                    start.clone().sunday()
+                    start.clone().next().sunday()
                 );
             },
-            update_interval: function(start, end)
-            {
+            update_interval: function (start, end) {
                 var start_str = instance.web.auto_date_to_str(
                         start, this.field.type
                     ),
                     end_str = instance.web.auto_date_to_str(
                         end,
                         this.field_manager.fields[this.options.end_field]
-                        .field.type
+                            .field.type
                     ),
                     values = {};
                 values[this.name] = start_str;
                 values[this.options.end_field] = end_str;
                 this.field_manager.set_values(values);
                 this.reinitialize();
-             },
+            },
         }
     );
 };

--- a/web_widget_date_interval/static/src/js/web_widget_date_interval.js
+++ b/web_widget_date_interval/static/src/js/web_widget_date_interval.js
@@ -42,6 +42,14 @@ openerp.web_widget_date_interval = function (instance) {
                 var local = date.clone().clearTime().add(12).hours();
                 return parseInt(local.getISOWeek(), 10);
             },
+            weeknumber_iso_year: function (date) {
+                // The ISO year of a week is the year of the week's thursday
+                var _date = date.clone();
+                if (!_date.is().monday()) {
+                    _date.last().monday();
+                }
+                return _date.next().thursday().getFullYear();
+            },
             weeknumber_iso_get_years: function () {
                 if (this.options.hide_years) {
                     return [];
@@ -75,17 +83,21 @@ openerp.web_widget_date_interval = function (instance) {
                 }
                 return result;
             },
+            weeknumber_iso_date_from_week: function (year, week) {
+                // Pick any date within 'year', then change the week
+                return new Date(year, 5, 1).setWeek(week);
+            },
             weeknumber_iso_onchange_year: function (e) {
-                var year = parseInt(jQuery(e.currentTarget).data('year'), 10),
-                    value = this._get_date();
-                value.setFullYear(year);
-                return this.weeknumber_iso_update_interval(value);
+                var year = parseInt(jQuery(e.currentTarget).data('year'), 10);
+                var week = this.weeknumber_iso_weeknumber(this._get_date());
+                var monday = this.weeknumber_iso_date_from_week(year, week);
+                return this.weeknumber_iso_update_interval(monday);
             },
             weeknumber_iso_onchange_week: function (e) {
                 var week = parseInt(jQuery(e.currentTarget).val(), 10);
-                return this.weeknumber_iso_update_interval(
-                    this._get_date().setWeek(week)
-                );
+                var year = this.weeknumber_iso_year(this._get_date());
+                var monday = this.weeknumber_iso_date_from_week(year, week);
+                return this.weeknumber_iso_update_interval(monday);
             },
             weeknumber_iso_update_interval: function (start) {
                 return this.update_interval(

--- a/web_widget_date_interval/static/src/xml/web_widget_date_interval.xml
+++ b/web_widget_date_interval/static/src/xml/web_widget_date_interval.xml
@@ -9,7 +9,7 @@
                     t-as="year"
                     t-att-data-year="year"
                     t-attf-class="oe_button oe_form_button"
-                    t-att-disabled="date.getFullYear() == year ? 'disable' : null"
+                    t-att-disabled="widget.weeknumber_iso_year(date) == year ? 'disable' : null"
                 >
                     <t
                         t-esc="year"


### PR DESCRIPTION
On selecting the first or last week of a year, the year could switch forward or backward and even display incorrectly because of incorrect treatment of ISO week years.

Fixed together with some linter improvements.